### PR TITLE
Fix vercel function runtime version

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -28,10 +28,5 @@
         }
       ]
     }
-  ],
-  "functions": {
-    "src/api/*.js": {
-      "runtime": "nodejs18.x"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
Remove unused `functions` configuration from `vercel.json` to resolve Vercel deployment error.

The project is a Vue.js SPA and does not utilize serverless functions, making the `functions` block in `vercel.json` extraneous and causing a deployment error related to function runtimes.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ec397ae-7adf-42d8-9e30-1b91cd8f9fea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ec397ae-7adf-42d8-9e30-1b91cd8f9fea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

